### PR TITLE
Prepare for next release and remove rust-toolchain configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cc"
-version = "1.2.32"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
  "shlex",
 ]
@@ -320,7 +320,7 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "xsf"
-version = "0.0.0+0.1.2"
+version = "0.1.0+0.1.2"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,10 @@
 [package]
 name = "xsf"
-version = "0.0.0+0.1.2"
+version = "0.1.0+0.1.2"
 authors = ["Joren Hammudoglu <jhammudoglu@gmail.com>"]
 categories = ["api-bindings", "mathematics", "science"]
 edition = "2024"
-exclude = [
-  "**/.github/*",
-  "**/.vscode/*",
-]
+exclude = ["**/.github/*", "**/.vscode/*"]
 keywords = ["ffi", "bindings", "math", "xsf", "scipy"]
 license = "BSD-3-Clause AND MIT AND BSD-3-Clause-LBNL AND Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.88"


### PR DESCRIPTION
Update package versions and clean up configuration by removing the rust-toolchain file in preparation for the next release.