### PR TITLE
prolate/oblate spheroidal angular- and radial functions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -240,9 +240,20 @@ const XSF_TYPES: &[(&str, &str)] = &[
     //  TODO: `sph_harm_y_all`: dd->[[d]]
     ("sph_harm_y", "iidd->D"),
     // sphd_wave.h
-    //  TODO: `*_aswfa*` and `*_radial*`
     ("prolate_segv", "ddd->d"),
+    ("prolate_aswfa_nocv", "dddd->dd"),
+    ("prolate_radial1_nocv", "dddd->dd"),
+    ("prolate_radial2_nocv", "dddd->dd"),
+    ("prolate_aswfa", "ddddd->dd"),
+    ("prolate_radial1", "ddddd->dd"),
+    ("prolate_radial2", "ddddd->dd"),
     ("oblate_segv", "ddd->d"),
+    ("oblate_aswfa_nocv", "dddd->dd"),
+    ("oblate_radial1_nocv", "dddd->dd"),
+    ("oblate_radial2_nocv", "dddd->dd"),
+    ("oblate_radial1", "ddddd->dd"),
+    ("oblate_radial2", "ddddd->dd"),
+    ("oblate_aswfa", "ddddd->dd"),
     // stats.h
     ("bdtr", "did->d"),
     ("bdtrc", "did->d"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,11 @@ pub use sph_harm::sph_harm_y;
 
 // sphd_wave.h
 mod sphd_wave;
-pub use sphd_wave::{oblate_segv, prolate_segv};
+pub use sphd_wave::{
+    oblate_aswfa, oblate_aswfa_nocv, oblate_radial1, oblate_radial1_nocv, oblate_radial2,
+    oblate_radial2_nocv, oblate_segv, prolate_aswfa, prolate_aswfa_nocv, prolate_radial1,
+    prolate_radial1_nocv, prolate_radial2, prolate_radial2_nocv, prolate_segv,
+};
 
 // stats.h
 mod stats;

--- a/src/sphd_wave.rs
+++ b/src/sphd_wave.rs
@@ -206,7 +206,7 @@ pub fn oblate_aswfa(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
 /// - `n`: Mode parameter (*n >= m*)
 /// - `c`: Spheroidal parameter
 /// - `cv`: Characteristic value
-/// - `x`: Real argument (*|x| < 1*)
+/// - `x`: Real argument (*x > 1*)
 ///
 /// # Returns
 /// - `s`: Value of the function
@@ -230,7 +230,7 @@ pub fn prolate_radial1(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
 /// - `n`: Mode parameter (*n >= m*)
 /// - `c`: Spheroidal parameter
 /// - `cv`: Characteristic value
-/// - `x`: Real argument (*|x| < 1*)
+/// - `x`: Real argument (*x > 1*)
 ///
 /// # Returns
 /// - `s`: Value of the function
@@ -254,7 +254,7 @@ pub fn oblate_radial1(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
 /// - `n`: Mode parameter (*n >= m*)
 /// - `c`: Spheroidal parameter
 /// - `cv`: Characteristic value
-/// - `x`: Real argument (*|x| < 1*)
+/// - `x`: Real argument (*x > 1*)
 ///
 /// # Returns
 /// - `s`: Value of the function
@@ -278,7 +278,7 @@ pub fn prolate_radial2(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
 /// - `n`: Mode parameter (*n >= m*)
 /// - `c`: Spheroidal parameter
 /// - `cv`: Characteristic value
-/// - `x`: Real argument (*|x| < 1*)
+/// - `x`: Real argument (*x > 1*)
 ///
 /// # Returns
 /// - `s`: Value of the function

--- a/src/sphd_wave.rs
+++ b/src/sphd_wave.rs
@@ -9,3 +9,285 @@ pub fn prolate_segv(m: u64, n: u64, c: f64) -> f64 {
 pub fn oblate_segv(m: u64, n: u64, c: f64) -> f64 {
     unsafe { bindings::oblate_segv(m as f64, n as f64, c) }
 }
+
+/// Prolate spheroidal angular function of the 1st kind and its derivative
+///
+/// Computes the prolate spheroidal angular function of the first kind and its derivative (with
+/// respect to `x`).
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn prolate_aswfa_nocv(m: u64, n: u64, c: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::prolate_aswfa_nocv(m as f64, n as f64, c, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Oblate spheroidal angular function of the 1st kind and its derivative
+///
+/// Computes the oblate spheroidal angular function of the first kind and its derivative (with
+/// respect to `x`).
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn oblate_aswfa_nocv(m: u64, n: u64, c: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::oblate_aswfa_nocv(m as f64, n as f64, c, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Prolate spheroidal radial function of the 1st kind and its derivative
+///
+/// Computes the prolate spheroidal radial function of the first kind and its derivative (with
+/// respect to `x`).
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `x`: Real argument (*x > 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn prolate_radial1_nocv(m: u64, n: u64, c: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::prolate_radial1_nocv(m as f64, n as f64, c, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Oblate spheroidal radial function of the 1st kind and its derivative
+///
+/// Computes the oblate spheroidal radial function of the first kind and its derivative (with
+/// respect to `x`).
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `x`: Real argument (*x > 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn oblate_radial1_nocv(m: u64, n: u64, c: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::oblate_radial1_nocv(m as f64, n as f64, c, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Prolate spheroidal radial function of the 2nd kind and its derivative
+///
+/// Computes the prolate spheroidal radial function of the second kind and its derivative (with
+/// respect to `x`).
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `x`: Real argument (*x > 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn prolate_radial2_nocv(m: u64, n: u64, c: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::prolate_radial2_nocv(m as f64, n as f64, c, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Oblate spheroidal radial function of the second kind and its derivative
+///
+/// Computes the oblate spheroidal radial function of the second kind and its derivative (with
+/// respect to `x`).
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `x`: Real argument (*x > 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn oblate_radial2_nocv(m: u64, n: u64, c: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::oblate_radial2_nocv(m as f64, n as f64, c, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Prolate spheroidal angular function for precomputed characteristic value
+///
+/// Computes the prolate spheroidal angular function of the first kind and its derivative (with
+/// respect to `x`). Requires pre-computed characteristic value.
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `cv`: Characteristic value
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn prolate_aswfa(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::prolate_aswfa(m as f64, n as f64, c, cv, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Oblate spheroidal angular function for precomputed characteristic value
+///
+/// Computes the oblate spheroidal angular function of the first kind and its derivative (with
+/// respect to `x`). Requires pre-computed characteristic value.
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `cv`: Characteristic value
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn oblate_aswfa(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::oblate_aswfa(m as f64, n as f64, c, cv, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Prolate spheroidal radial function of the 1st kind for precomputed characteristic value
+///
+/// Computes the prolate spheroidal radial function of the first kind and its derivative (with
+/// respect to `x`). Requires pre-computed characteristic value.
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `cv`: Characteristic value
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn prolate_radial1(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::prolate_radial1(m as f64, n as f64, c, cv, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Oblate spheroidal radial function of the 1st kind for precomputed characteristic value
+///
+/// Computes the oblate spheroidal radial function of the first kind and its derivative (with
+/// respect to `x`). Requires pre-computed characteristic value.
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `cv`: Characteristic value
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn oblate_radial1(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::oblate_radial1(m as f64, n as f64, c, cv, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Prolate spheroidal radial function of the 2nd kind for precomputed characteristic value
+///
+/// Computes the prolate spheroidal radial function of the second kind and its derivative (with
+/// respect to `x`). Requires pre-computed characteristic value.
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `cv`: Characteristic value
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn prolate_radial2(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::prolate_radial2(m as f64, n as f64, c, cv, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}
+
+/// Oblate spheroidal radial function of the 2nd kind for precomputed characteristic value
+///
+/// Computes the oblate spheroidal radial function of the second kind and its derivative (with
+/// respect to `x`). Requires pre-computed characteristic value.
+///
+/// # Arguments
+/// - `m`: Mode parameter (*m >= 0*)
+/// - `n`: Mode parameter (*n >= m*)
+/// - `c`: Spheroidal parameter
+/// - `cv`: Characteristic value
+/// - `x`: Real argument (*|x| < 1*)
+///
+/// # Returns
+/// - `s`: Value of the function
+/// - `sp` : Value of the derivative w.r.t. `x`
+pub fn oblate_radial2(m: u64, n: u64, c: f64, cv: f64, x: f64) -> (f64, f64) {
+    let mut s = f64::NAN;
+    let mut sp = f64::NAN;
+    unsafe {
+        bindings::oblate_radial2(m as f64, n as f64, c, cv, x, &mut s, &mut sp);
+    }
+    (s, sp)
+}

--- a/tests/test_functions.rs
+++ b/tests/test_functions.rs
@@ -550,6 +550,26 @@ macro_rules! xsref_test {
             );
         }
     };
+    (@single $f:ident, "QQdd->dd") => {
+        paste::paste! {
+            _test!(
+                [<test_ $f _ d>],
+                $f, "d_d_d_d-d_d",
+                |x: &[f64]| xsf::$f(x[0] as u64, x[1] as u64, x[2], x[3]),
+                (f64, f64)
+            );
+        }
+    };
+    (@single $f:ident, "QQddd->dd") => {
+        paste::paste! {
+            _test!(
+                [<test_ $f _ d>],
+                $f, "d_d_d_d_d-d_d",
+                |x: &[f64]| xsf::$f(x[0] as u64, x[1] as u64, x[2], x[3], x[4]),
+                (f64, f64)
+            );
+        }
+    };
     (@single $f:ident, "qdd->d") => {
         paste::paste! {
             _test!(
@@ -956,6 +976,18 @@ xsref_test!(pmv, "qdd->d");
 // sphd_wave.h
 xsref_test!(prolate_segv, "QQd->d");
 // xsref_test!(oblate_segv, "QQd->d");  // missing xsref table?
+xsref_test!(prolate_aswfa_nocv, "QQdd->dd");
+xsref_test!(oblate_aswfa_nocv, "QQdd->dd");
+xsref_test!(prolate_radial1_nocv, "QQdd->dd");
+xsref_test!(oblate_radial1_nocv, "QQdd->dd");
+xsref_test!(prolate_radial2_nocv, "QQdd->dd");
+xsref_test!(oblate_radial2_nocv, "QQdd->dd");
+xsref_test!(prolate_aswfa, "QQddd->dd");
+xsref_test!(oblate_aswfa, "QQddd->dd");
+xsref_test!(prolate_radial1, "QQddd->dd");
+xsref_test!(oblate_radial1, "QQddd->dd");
+xsref_test!(prolate_radial2, "QQddd->dd");
+xsref_test!(oblate_radial2, "QQddd->dd");
 
 // stats.h
 xsref_test!(ndtr, "d->d", "D->D");


### PR DESCRIPTION
- `prolate_aswfa[_nocv]`
- `oblate_aswfa[_nocv]`
- `prolate_radial1[_nocv]`
- `oblate_radial1[_nocv]`
- `prolate_radial2[_nocv]`
- `oblate_radial2[_nocv]`