### PR TITLE
`extended_{absolute,relative}_error`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -21,7 +21,7 @@ const XSF_HEADERS: &[&str] = &[
     "evalpoly.h",
     "exp.h",
     "expint.h",
-    // "fp_error_metrics.h",
+    "fp_error_metrics.h",
     "fresnel.h",
     "gamma.h",
     "hyp2f1.h",
@@ -136,6 +136,11 @@ const XSF_TYPES: &[(&str, &str)] = &[
     ("expi", "d->d"),
     ("expi", "D->D"),
     ("scaled_exp1", "d->d"),
+    // fp_error_metrics.h
+    ("extended_absolute_error", "dd->d"),
+    ("extended_absolute_error", "DD->d"),
+    ("extended_relative_error", "dd->d"),
+    ("extended_relative_error", "DD->d"),
     // fresnel.h
     //  TODO: `fcszo`: ii->[D]
     ("fresnel", "d->dd"),
@@ -585,7 +590,9 @@ fn get_allowlist() -> String {
 fn generate_bindings(dir_out: &str, header: &str) {
     bindgen::Builder::default()
         .header(header)
+        .clang_args(["-x", "c++"])
         .enable_cxx_namespaces()
+        .dynamic_link_require_all(true)
         .size_t_is_usize(true)
         .sort_semantically(true)
         .derive_copy(false)

--- a/src/fp_error_metrics.rs
+++ b/src/fp_error_metrics.rs
@@ -1,0 +1,79 @@
+use crate::bindings;
+use num_complex::Complex;
+
+mod sealed {
+    use num_complex::Complex;
+
+    pub trait Sealed {}
+    impl Sealed for f64 {}
+    impl Sealed for Complex<f64> {}
+}
+
+pub trait ExtendedErrorArg: sealed::Sealed {
+    fn xsf_extended_absolute_error(self, other: Self) -> f64;
+    fn xsf_extended_relative_error(self, other: Self) -> f64;
+}
+
+impl ExtendedErrorArg for f64 {
+    fn xsf_extended_absolute_error(self, other: Self) -> f64 {
+        unsafe { bindings::extended_absolute_error(self, other) }
+    }
+    fn xsf_extended_relative_error(self, other: Self) -> f64 {
+        unsafe { bindings::extended_relative_error(self, other) }
+    }
+}
+
+impl ExtendedErrorArg for Complex<f64> {
+    fn xsf_extended_absolute_error(self, other: Self) -> f64 {
+        unsafe { bindings::extended_absolute_error_1(self.into(), other.into()) }
+    }
+    fn xsf_extended_relative_error(self, other: Self) -> f64 {
+        unsafe { bindings::extended_relative_error_1(self.into(), other.into()) }
+    }
+}
+
+/// Extended absolute error metric between two `f64` or `Complex<f64>` values
+pub fn extended_absolute_error<T: ExtendedErrorArg>(actual: T, expected: T) -> f64 {
+    actual.xsf_extended_absolute_error(expected)
+}
+
+/// Extended relative error metric between two `f64` or `Complex<f64>` values
+pub fn extended_relative_error<T: ExtendedErrorArg>(actual: T, expected: T) -> f64 {
+    actual.xsf_extended_relative_error(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_complex::c64;
+
+    #[test]
+    fn test_extended_absolute_error_f64() {
+        assert_eq!(extended_absolute_error(0.0, 0.0), 0.0);
+        assert_eq!(extended_absolute_error(1.0, 0.0), 1.0);
+        assert_eq!(extended_absolute_error(1.0, 2.0), 1.0);
+        assert_eq!(extended_absolute_error(2.0, 1.0), 1.0);
+        assert_eq!(extended_absolute_error(3.0, 1.0), 2.0);
+    }
+
+    #[test]
+    fn test_extended_absolute_error_c64() {
+        assert_eq!(extended_absolute_error(c64(1.0, 1.0), c64(1.0, 1.0)), 0.0);
+        assert_eq!(extended_absolute_error(c64(0.0, 0.0), c64(3.0, 4.0)), 5.0);
+    }
+
+    #[test]
+    fn test_extended_relative_error_f64() {
+        assert_eq!(extended_relative_error(0.0, 0.0), 0.0);
+        assert_eq!(extended_relative_error(1.0, 0.0), f64::INFINITY);
+        assert_eq!(extended_relative_error(1.0, 2.0), 0.5);
+        assert_eq!(extended_relative_error(2.0, 1.0), 1.0);
+        assert_eq!(extended_relative_error(3.0, 1.0), 2.0);
+    }
+
+    #[test]
+    fn test_extended_relative_error_c64() {
+        assert_eq!(extended_relative_error(c64(1.0, 1.0), c64(1.0, 1.0)), 0.0);
+        assert_eq!(extended_relative_error(c64(0.0, 0.0), c64(3.0, 4.0)), 1.0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,10 @@ pub use exp::{exp2, exp10, expm1};
 mod expint;
 pub use expint::{exp1, expi, scaled_exp1};
 
+// fp_error_metrics.h
+mod fp_error_metrics;
+pub use fp_error_metrics::{extended_absolute_error, extended_relative_error};
+
 // fresnel.h
 mod fresnel;
 pub use fresnel::{fresnel, modified_fresnel_minus, modified_fresnel_plus};

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,41 +1,25 @@
 use arrow::array::{Array, Float64Array, Int32Array, Int64Array};
 use num_complex::{Complex, c64};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
-use std::env;
 use std::fs::File;
 use std::path::PathBuf;
+use std::{env, fmt::Display};
 
-pub trait TestOutputValue: Copy {
-    fn error(self, expected: Self) -> f64;
+use crate::fp_error_metrics::{ExtendedErrorArg, extended_relative_error};
+
+pub(crate) trait TestOutputValue: Copy + ExtendedErrorArg + Display {
     fn magnitude(self) -> f64;
-    fn format(self) -> String;
 }
 
 impl TestOutputValue for f64 {
-    fn error(self, expected: Self) -> f64 {
-        relative_error(self, expected)
-    }
-
     fn magnitude(self) -> f64 {
         self.abs()
-    }
-
-    fn format(self) -> String {
-        format!("{:.6e}", self)
     }
 }
 
 impl TestOutputValue for Complex<f64> {
-    fn error(self, expected: Self) -> f64 {
-        complex_relative_error(self, expected)
-    }
-
     fn magnitude(self) -> f64 {
         self.norm()
-    }
-
-    fn format(self) -> String {
-        format!("{:.6e}+{:.6e}i", self.re, self.im)
     }
 }
 
@@ -64,20 +48,20 @@ pub trait TestOutput: Copy {
         self.values()
             .iter()
             .zip(expected.values().iter())
-            .map(|(&a, &e)| a.error(e))
+            .map(|(&a, &e)| extended_relative_error(a, e))
             .fold(0.0, |acc, x| acc.max(x))
     }
 
     fn format(self) -> String {
         let values = self.values();
         if values.len() == 1 {
-            values[0].format()
+            format!("{}", values[0])
         } else {
             format!(
                 "({})",
                 values
                     .iter()
-                    .map(|x| x.format())
+                    .map(|x| format!("{x}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             )
@@ -271,10 +255,10 @@ fn load_testcases<T: TestOutput>(
         .join("scipy_special_tests")
         .join(name);
 
-    let get_table = |name: &str| File::open(tables_dir.join(format!("{}.parquet", name)));
+    let get_table = |name: &str| File::open(tables_dir.join(format!("{name}.parquet")));
 
-    let table_in = read_parquet_rows(get_table(&format!("In_{}", signature))?);
-    let table_out = read_parquet_output::<T>(get_table(&format!("Out_{}", signature))?);
+    let table_in = read_parquet_rows(get_table(&format!("In_{signature}"))?);
+    let table_out = read_parquet_output::<T>(get_table(&format!("Out_{signature}"))?);
 
     let platform = if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
         "gcc-linux-x86_64"
@@ -284,8 +268,8 @@ fn load_testcases<T: TestOutput>(
         "other"
     };
 
-    let table_err_file = get_table(&format!("Err_{}_{}", signature, platform))
-        .or_else(|_| get_table(&format!("Err_{}_other", signature)))?;
+    let table_err_file = get_table(&format!("Err_{signature}_{platform}"))
+        .or_else(|_| get_table(&format!("Err_{signature}_other")))?;
     let table_err = read_parquet_column(table_err_file);
 
     let test_cases = table_in
@@ -300,95 +284,6 @@ fn load_testcases<T: TestOutput>(
         .collect();
 
     Ok(test_cases)
-}
-
-/// based on `xsref.float_tools.extended_absolute_error`
-fn absolute_error(actual: f64, desired: f64) -> f64 {
-    if actual == desired || (actual.is_nan() && desired.is_nan()) {
-        return 0.0;
-    } else if desired.is_nan() || actual.is_nan() {
-        return f64::INFINITY;
-    }
-
-    // f64::MAX + ULP
-    let max1p = f64::MAX * (1.0 + 2.0_f64.powi(-(f64::MANTISSA_DIGITS as i32)));
-    if actual.is_infinite() {
-        (actual.signum() * max1p - desired).abs()
-    } else if desired.is_infinite() {
-        (actual - desired.signum() * max1p).abs()
-    } else {
-        (actual - desired).abs()
-    }
-}
-
-/// based on `xsref.float_tools.extended_relative_error`
-fn relative_error(actual: f64, desired: f64) -> f64 {
-    let abserr0 = if desired == 0.0 {
-        f64::MIN_POSITIVE
-    } else if desired.is_infinite() {
-        f64::MAX
-    } else if desired.is_nan() {
-        1.0
-    } else {
-        desired.abs()
-    };
-
-    let abserr = absolute_error(actual, desired);
-    (abserr / abserr0).min(abserr)
-}
-
-/// based on `xsref.float_tools.extended_absolute_error_complex`
-fn complex_absolute_error(actual: Complex<f64>, expected: Complex<f64>) -> f64 {
-    let real_error = (actual.re - expected.re).abs();
-    let imag_error = (actual.im - expected.im).abs();
-
-    let max_error = real_error.max(imag_error);
-    if max_error == 0.0 {
-        0.0
-    } else if max_error.is_infinite() {
-        f64::INFINITY
-    } else {
-        real_error.hypot(imag_error)
-    }
-}
-
-/// based on `xsref.float_tools.extended_relative_error_complex`
-fn complex_relative_error(actual: Complex<f64>, expected: Complex<f64>) -> f64 {
-    if actual.re.is_nan() || actual.im.is_nan() {
-        if expected.re.is_nan() || expected.im.is_nan() {
-            0.0
-        } else {
-            f64::INFINITY
-        }
-    } else if expected.re.is_infinite() || expected.im.is_infinite() {
-        // If any component of expected is infinite, use component-wise relative error
-        fn rel_error(x: f64, y: f64) -> f64 {
-            if y.is_infinite() {
-                if x.is_infinite() && x.signum() == y.signum() {
-                    0.0
-                } else {
-                    f64::INFINITY
-                }
-            } else if y == 0.0 {
-                x.abs()
-            } else {
-                (x / y - 1.0).abs()
-            }
-        }
-
-        let real_rel_err = rel_error(actual.re, expected.re);
-        let imag_rel_err = rel_error(actual.im, expected.im);
-        real_rel_err.max(imag_rel_err)
-    } else {
-        // For finite expected values, use the magnitude-based relative error
-        let abs_error = complex_absolute_error(actual, expected);
-        let expected_magnitude = expected.re.hypot(expected.im);
-        if expected_magnitude == 0.0 {
-            abs_error
-        } else {
-            abs_error / expected_magnitude
-        }
-    }
 }
 
 pub fn test<T, F>(name: &str, signature: &str, test_fn: F)


### PR DESCRIPTION
this helped simplify the internal testing code quite a bit