### PR TITLE
improved api consistency for legendre Q functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,8 @@ pub use lambertw::lambertw;
 mod legendre;
 pub use legendre::{
     assoc_legendre_p, assoc_legendre_p_all, assoc_legendre_p_norm, assoc_legendre_p_norm_all,
-    legendre_p, legendre_p_all, lqmn, lqn, sph_legendre_p, sph_legendre_p_all,
+    assoc_legendre_q_all, legendre_p, legendre_p_all, legendre_q_all, sph_legendre_p,
+    sph_legendre_p_all,
 };
 
 // log_exp.h


### PR DESCRIPTION
- `lqn(n, z)` -> `legendre_q_all(n, z)`
- `lqmn(m, n, z)` -> `assoc_legendre_q_all(n, m, z)`
