### PR TITLE
transparent `std::complex` wrapping

### DIFF
--- a/src/airy.rs
+++ b/src/airy.rs
@@ -44,10 +44,10 @@ impl AiryArg for f64 {
 impl AiryArg for Complex<f64> {
     #[inline(always)]
     fn airy(self) -> (Self, Self, Self, Self) {
-        let mut ai = bindings::complex_nan();
-        let mut bi = bindings::complex_nan();
-        let mut ad = bindings::complex_nan();
-        let mut bd = bindings::complex_nan();
+        let mut ai = f64::NAN.into();
+        let mut bi = f64::NAN.into();
+        let mut ad = f64::NAN.into();
+        let mut bd = f64::NAN.into();
 
         unsafe {
             bindings::airy_1(self.into(), &mut ai, &mut bi, &mut ad, &mut bd);
@@ -57,10 +57,10 @@ impl AiryArg for Complex<f64> {
 
     #[inline(always)]
     fn airye(self) -> (Self, Self, Self, Self) {
-        let mut ai = bindings::complex_nan();
-        let mut bi = bindings::complex_nan();
-        let mut ad = bindings::complex_nan();
-        let mut bd = bindings::complex_nan();
+        let mut ai = f64::NAN.into();
+        let mut bi = f64::NAN.into();
+        let mut ad = f64::NAN.into();
+        let mut bd = f64::NAN.into();
 
         unsafe {
             bindings::airye_1(self.into(), &mut ai, &mut bi, &mut ad, &mut bd);

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2,60 +2,46 @@
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 
-use alloc::vec::Vec;
-use num_complex::Complex;
-
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-pub(crate) use root::std::complex;
 pub(crate) use root::xsf_wrapper::*;
-
-pub(crate) type cdouble = complex<f64>;
 
 // C++ std::complex type wrapper
 
 impl cdouble {
     pub(crate) fn new(re: f64, im: f64) -> Self {
-        unsafe { complex__new(re, im) }
+        Self { re, im }
     }
 }
 
-impl From<Complex<f64>> for cdouble {
-    fn from(z: Complex<f64>) -> Self {
+impl Default for cdouble {
+    fn default() -> Self {
+        Self::new(0.0, 0.0)
+    }
+}
+
+impl From<f64> for cdouble {
+    fn from(x: f64) -> Self {
+        Self::new(x, 0.0)
+    }
+}
+
+impl From<num_complex::Complex<f64>> for cdouble {
+    fn from(z: num_complex::Complex<f64>) -> Self {
         Self::new(z.re, z.im)
     }
 }
 
-impl From<cdouble> for Complex<f64> {
+impl From<cdouble> for num_complex::Complex<f64> {
     fn from(z: cdouble) -> Self {
-        let mut re: f64 = 0.0;
-        let mut im: f64 = 0.0;
-        unsafe {
-            complex__values(z, &mut re, &mut im);
-        }
-        Self::new(re, im)
+        Self::new(z.re, z.im)
     }
 }
 
-// complex helper functions
-
-#[inline(always)]
-pub(crate) fn complex_nan() -> cdouble {
-    complex::new(f64::NAN, f64::NAN)
-}
-
-#[inline(always)]
-pub(crate) fn complex_zeros(n: usize) -> Vec<cdouble> {
-    (0..n).map(|_| complex::new(0.0, 0.0)).collect()
-}
-
-#[inline(always)]
-pub(crate) fn cvec_into<T>(xs: Vec<complex<T>>) -> Vec<Complex<T>>
-where
-    Complex<T>: From<complex<T>>,
-{
-    xs.into_iter().map(|c| c.into()).collect()
-}
+pub(crate) const CNAN: cdouble = cdouble {
+    re: f64::NAN,
+    im: f64::NAN,
+};
 
 // macros
 

--- a/src/fresnel.rs
+++ b/src/fresnel.rs
@@ -1,4 +1,5 @@
-use crate::bindings;
+use crate::{bindings, utils};
+use alloc::vec;
 use alloc::vec::Vec;
 use core::ffi::c_int;
 use num_complex::Complex;
@@ -33,8 +34,8 @@ impl FresnelArg for Complex<f64> {
 
     #[inline(always)]
     fn fresnel(self) -> (Self::Output, Self::Output) {
-        let mut fs = bindings::complex_nan();
-        let mut fc = bindings::complex_nan();
+        let mut fs = f64::NAN.into();
+        let mut fc = f64::NAN.into();
         unsafe {
             bindings::fresnel_1(self.into(), &mut fs, &mut fc);
         }
@@ -68,8 +69,8 @@ pub fn fresnel<T: FresnelArg>(z: T) -> (T::Output, T::Output) {
 /// - [`fresnel`] - Standard Fresnel integrals
 /// - [`modified_fresnel_minus`] - Modified Fresnel negative integrals
 pub fn modified_fresnel_plus(x: f64) -> (Complex<f64>, Complex<f64>) {
-    let mut fp = bindings::complex_nan();
-    let mut kp = bindings::complex_nan();
+    let mut fp = f64::NAN.into();
+    let mut kp = f64::NAN.into();
     unsafe {
         bindings::modified_fresnel_plus(x, &mut fp, &mut kp);
     }
@@ -86,8 +87,8 @@ pub fn modified_fresnel_plus(x: f64) -> (Complex<f64>, Complex<f64>) {
 /// - [`fresnel`] - Standard Fresnel integrals S(z) and C(z)
 /// - [`modified_fresnel_plus`] - Modified Fresnel positive integrals
 pub fn modified_fresnel_minus(x: f64) -> (Complex<f64>, Complex<f64>) {
-    let mut fm = bindings::complex_nan();
-    let mut km = bindings::complex_nan();
+    let mut fm = f64::NAN.into();
+    let mut km = f64::NAN.into();
     unsafe {
         bindings::modified_fresnel_minus(x, &mut fm, &mut km);
     }
@@ -105,13 +106,13 @@ pub fn modified_fresnel_minus(x: f64) -> (Complex<f64>, Complex<f64>) {
 pub fn fresnel_zeros(nt: usize) -> (Vec<Complex<f64>>, Vec<Complex<f64>>) {
     assert!(nt <= c_int::MAX as usize);
 
-    let mut szo = bindings::complex_zeros(nt);
-    let mut czo = bindings::complex_zeros(nt);
+    let mut szo = vec![bindings::cdouble::default(); nt];
+    let mut czo = vec![bindings::cdouble::default(); nt];
     unsafe {
         bindings::fcszo(2, nt as c_int, szo.as_mut_ptr());
         bindings::fcszo(1, nt as c_int, czo.as_mut_ptr());
     }
-    (bindings::cvec_into(szo), bindings::cvec_into(czo))
+    (utils::vec_into(szo), utils::vec_into(czo))
 }
 
 #[cfg(test)]

--- a/src/kelvin.rs
+++ b/src/kelvin.rs
@@ -22,10 +22,10 @@ xsf_impl!(keip, (x: f64), "Derivative of the Kelvin function `kei`");
 /// - *Be*': Derivative of [`berp`] + *i* [`beip`]
 /// - *Ke*': Derivative of [`kerp`] + *i* [`keip`]
 pub fn kelvin(x: f64) -> [Complex<f64>; 4] {
-    let mut be = bindings::complex_nan();
-    let mut ke = bindings::complex_nan();
-    let mut bep = bindings::complex_nan();
-    let mut kep = bindings::complex_nan();
+    let mut be = f64::NAN.into();
+    let mut ke = f64::NAN.into();
+    let mut bep = f64::NAN.into();
+    let mut kep = f64::NAN.into();
     unsafe {
         bindings::kelvin(x, &mut be, &mut ke, &mut bep, &mut kep);
     }

--- a/src/legendre.rs
+++ b/src/legendre.rs
@@ -1,4 +1,5 @@
 use crate::{bindings, utils};
+use alloc::vec;
 use alloc::vec::Vec;
 use core::ffi::c_int;
 use num_complex::Complex;
@@ -26,7 +27,7 @@ impl LegendrePArg for f64 {
 
     #[inline(always)]
     fn legendre_p_all(self, n: usize) -> Vec<Self> {
-        let mut pn = alloc::vec![0.0; n + 1];
+        let mut pn = vec![0.0; n + 1];
         unsafe {
             bindings::legendre_p_all(n, self, pn.as_mut_ptr());
         }
@@ -41,7 +42,7 @@ impl LegendrePArg for f64 {
     #[inline(always)]
     fn sph_legendre_p_all(self, n: usize, m: usize) -> Vec<Vec<Self>> {
         let (ni, nj) = (n + 1, 2 * m + 1);
-        let mut pnm = alloc::vec![0.0; ni * nj];
+        let mut pnm = vec![0.0; ni * nj];
         unsafe {
             bindings::sph_legendre_p_all(n, m, self, pnm.as_mut_ptr());
         }
@@ -62,7 +63,7 @@ impl LegendrePArg for f64 {
     #[inline(always)]
     fn assoc_legendre_p_all(self, n: usize, m: usize, bc: c_int, norm: bool) -> Vec<Vec<Self>> {
         let (ni, nj) = (n + 1, 2 * m + 1);
-        let mut pnm = alloc::vec![0.0; ni * nj];
+        let mut pnm = vec![0.0; ni * nj];
         unsafe {
             if norm {
                 bindings::assoc_legendre_p_all_1(n, m, self, bc, pnm.as_mut_ptr());
@@ -82,11 +83,11 @@ impl LegendrePArg for Complex<f64> {
 
     #[inline(always)]
     fn legendre_p_all(self, n: usize) -> Vec<Self> {
-        let mut pn = bindings::complex_zeros(n + 1);
+        let mut pn = vec![bindings::cdouble::default(); n + 1];
         unsafe {
             bindings::legendre_p_all_1(n, self.into(), pn.as_mut_ptr());
         }
-        bindings::cvec_into(pn)
+        utils::vec_into(pn)
     }
 
     #[inline(always)]
@@ -97,11 +98,11 @@ impl LegendrePArg for Complex<f64> {
     #[inline(always)]
     fn sph_legendre_p_all(self, n: usize, m: usize) -> Vec<Vec<Self>> {
         let (ni, nj) = (n + 1, 2 * m + 1);
-        let mut pnm = bindings::complex_zeros(ni * nj);
+        let mut pnm = vec![bindings::cdouble::default(); ni * nj];
         unsafe {
             bindings::sph_legendre_p_all_1(n, m, self.into(), pnm.as_mut_ptr());
         }
-        utils::vec_to_vecvec(bindings::cvec_into(pnm), ni, nj, false)
+        utils::vec_to_vecvec(utils::vec_into(pnm), ni, nj, false)
     }
 
     #[inline(always)]
@@ -119,7 +120,7 @@ impl LegendrePArg for Complex<f64> {
     #[inline(always)]
     fn assoc_legendre_p_all(self, n: usize, m: usize, bc: c_int, norm: bool) -> Vec<Vec<Self>> {
         let (ni, nj) = (n + 1, 2 * m + 1);
-        let mut pnm = bindings::complex_zeros(ni * nj);
+        let mut pnm = vec![bindings::cdouble::default(); ni * nj];
         unsafe {
             if norm {
                 bindings::assoc_legendre_p_all_1_1(n, m, self.into(), bc, pnm.as_mut_ptr());
@@ -127,7 +128,7 @@ impl LegendrePArg for Complex<f64> {
                 bindings::assoc_legendre_p_all_0_1(n, m, self.into(), bc, pnm.as_mut_ptr());
             }
         }
-        utils::vec_to_vecvec(bindings::cvec_into(pnm), ni, nj, false)
+        utils::vec_to_vecvec(utils::vec_into(pnm), ni, nj, false)
     }
 }
 
@@ -139,8 +140,8 @@ pub trait LegendreQArg: sealed::Sealed + Sized {
 impl LegendreQArg for f64 {
     #[inline(always)]
     fn legendre_q_all(self, n: usize) -> (Vec<Self>, Vec<Self>) {
-        let mut qn = alloc::vec![0.0; n + 1];
-        let mut qd = alloc::vec![0.0; n + 1];
+        let mut qn = vec![0.0; n + 1];
+        let mut qd = vec![0.0; n + 1];
 
         unsafe {
             bindings::lqn(n, self, qn.as_mut_ptr(), qd.as_mut_ptr());
@@ -151,8 +152,8 @@ impl LegendreQArg for f64 {
     #[inline(always)]
     fn assoc_legendre_q_all(self, n: usize, m: usize) -> (Vec<Vec<Self>>, Vec<Vec<Self>>) {
         let (ni, nj) = (m + 1, n + 1);
-        let mut qm = alloc::vec![0.0; ni * nj];
-        let mut qd = alloc::vec![0.0; ni * nj];
+        let mut qm = vec![0.0; ni * nj];
+        let mut qd = vec![0.0; ni * nj];
 
         unsafe {
             bindings::lqmn(m, n, self, qm.as_mut_ptr(), qd.as_mut_ptr());
@@ -169,20 +170,20 @@ impl LegendreQArg for f64 {
 impl LegendreQArg for Complex<f64> {
     #[inline(always)]
     fn legendre_q_all(self, n: usize) -> (Vec<Self>, Vec<Self>) {
-        let mut cqn: Vec<_> = bindings::complex_zeros(n + 1);
-        let mut cqd: Vec<_> = bindings::complex_zeros(n + 1);
+        let mut cqn: Vec<_> = vec![bindings::cdouble::default(); n + 1];
+        let mut cqd: Vec<_> = vec![bindings::cdouble::default(); n + 1];
 
         unsafe {
             bindings::lqn_1(n, self.into(), cqn.as_mut_ptr(), cqd.as_mut_ptr());
         }
-        (bindings::cvec_into(cqn), bindings::cvec_into(cqd))
+        (utils::vec_into(cqn), utils::vec_into(cqd))
     }
 
     #[inline(always)]
     fn assoc_legendre_q_all(self, n: usize, m: usize) -> (Vec<Vec<Self>>, Vec<Vec<Self>>) {
         let (ni, nj) = (m + 1, n + 1);
-        let mut cqm = bindings::complex_zeros(ni * nj);
-        let mut cqd = bindings::complex_zeros(ni * nj);
+        let mut cqm = vec![bindings::cdouble::default(); ni * nj];
+        let mut cqd = vec![bindings::cdouble::default(); ni * nj];
 
         unsafe {
             bindings::lqmn_1(m, n, self.into(), cqm.as_mut_ptr(), cqd.as_mut_ptr());
@@ -190,8 +191,8 @@ impl LegendreQArg for Complex<f64> {
 
         // Convert from flat vec to matrix (m+1, n+1) and transpose to (n+1, m+1)
         (
-            utils::vec_to_vecvec(bindings::cvec_into(cqm), ni, nj, true),
-            utils::vec_to_vecvec(bindings::cvec_into(cqd), ni, nj, true),
+            utils::vec_to_vecvec(utils::vec_into(cqm), ni, nj, true),
+            utils::vec_to_vecvec(utils::vec_into(cqd), ni, nj, true),
         )
     }
 }

--- a/src/sici.rs
+++ b/src/sici.rs
@@ -39,8 +39,8 @@ impl SiciArg for f64 {
 impl SiciArg for Complex<f64> {
     #[inline(always)]
     fn sici(self) -> (Self, Self) {
-        let mut si = bindings::complex_nan();
-        let mut ci = bindings::complex_nan();
+        let mut si = f64::NAN.into();
+        let mut ci = f64::NAN.into();
 
         unsafe {
             bindings::sici_1(self.into(), &mut si, &mut ci);
@@ -50,8 +50,8 @@ impl SiciArg for Complex<f64> {
 
     #[inline(always)]
     fn shichi(self) -> (Self, Self) {
-        let mut shi = bindings::complex_nan();
-        let mut chi = bindings::complex_nan();
+        let mut shi = f64::NAN.into();
+        let mut chi = f64::NAN.into();
 
         unsafe {
             bindings::shichi_1(self.into(), &mut shi, &mut chi);

--- a/src/sph_harm.rs
+++ b/src/sph_harm.rs
@@ -1,4 +1,5 @@
 use crate::{bindings, utils};
+use alloc::vec;
 use alloc::vec::Vec;
 use core::ffi::c_int;
 use num_complex::Complex;
@@ -21,9 +22,9 @@ pub fn sph_harm_y(n: usize, m: isize, theta: f64, phi: f64) -> Complex<f64> {
 /// - Index `m+1` to `2*m`: orders `-m, -(m-1), ..., -1`
 pub fn sph_harm_y_all(n: usize, m: usize, theta: f64, phi: f64) -> Vec<Vec<Complex<f64>>> {
     let (nr, nc) = (n + 1, 2 * m + 1);
-    let mut res = bindings::complex_zeros(nr * nc);
+    let mut res = vec![bindings::cdouble::default(); nr * nc];
     unsafe { bindings::sph_harm_y_all(n, m, theta, phi, res.as_mut_ptr()) };
-    utils::vec_to_vecvec(bindings::cvec_into(res), nr, nc, false)
+    utils::vec_to_vecvec(utils::vec_into(res), nr, nc, false)
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,3 +19,11 @@ pub(crate) fn vec_to_vecvec<T: Clone>(
             .collect()
     }
 }
+
+#[inline(always)]
+pub(crate) fn vec_into<S, T>(xs: Vec<S>) -> Vec<T>
+where
+    S: Into<T>,
+{
+    xs.into_iter().map(S::into).collect()
+}


### PR DESCRIPTION
This refactors the code related to `std::complex` so that the wrapping/unwrapping logic now takes place on the C++ side of things. This allows for a cleaner rust API, but results in a slightly more complex C++ wrappers. But because of that, the C++ compliler will be able to apply more potential optimizations,which could be beneficial for performance.