### PR TITLE
don't prefer clang cl over msvc anymore

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -873,7 +873,8 @@ fn build_wrapper(dir_out: &str) {
     let mut build = cc::Build::new();
     build
         .cpp(true)
-        .prefer_clang_cl_over_msvc(true)
+        // .prefer_clang_cl_over_msvc(true)
+        // .flag_if_supported("-fexceptions")
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-logical-op-parentheses")
         .include(XSF_INCLUDE)


### PR DESCRIPTION
this is an attempt at resolving resolve `error: cannot use 'throw' with exceptions disabled` in #46