### PR TITLE
`lgam1p` (hidden)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@ const WRAPPER_INCLUDES: &[&str] = &[
     "cephes/poch.h",
     "cephes/round.h",
     "cephes/spence.h",
+    "cephes/unity.h",
     "airy.h",
     "alg.h",
     "bessel.h",
@@ -423,6 +424,12 @@ double spence(double x) {
     return xsf::cephes::spence(x);
 }"#;
 
+// cephes/unity.h
+const _CPP_CEPHES_UNITY: &str = r#"
+double lgam1p(double x) {
+    return xsf::cephes::lgam1p(x);
+}"#;
+
 // airy.h
 
 const _CPP_AIRYZO: &str = r#"
@@ -616,6 +623,10 @@ const WRAPPER_SPECS_CUSTOM: &[WrapperSpecCustom] = &[
     WrapperSpecCustom {
         pattern: r"spence",
         cpp: _CPP_CEPHES_SPENCE,
+    },
+    WrapperSpecCustom {
+        pattern: r"lgam1p",
+        cpp: _CPP_CEPHES_UNITY,
     },
     WrapperSpecCustom {
         pattern: r"airyzo",

--- a/src/cephes/mod.rs
+++ b/src/cephes/mod.rs
@@ -6,3 +6,4 @@ pub mod lanczos;
 pub mod poch;
 pub mod round;
 pub mod spence;
+pub mod unity;

--- a/src/cephes/unity.rs
+++ b/src/cephes/unity.rs
@@ -1,0 +1,16 @@
+use crate::bindings;
+
+/// see `scipy.special._ufuncs._lgam1p`
+#[doc(hidden)]
+#[inline(always)]
+pub fn lgam1p(x: f64) -> f64 {
+    unsafe { bindings::lgam1p(x) }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_lgam1p() {
+        crate::testing::test("lgam1p", "d-d", |x| crate::lgam1p(x[0]));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub use cephes::lanczos::lanczos_sum_expg_scaled;
 pub use cephes::poch::{pow_falling, pow_rising};
 pub use cephes::round::round;
 pub use cephes::spence::spence;
+pub use cephes::unity::lgam1p;
 
 mod scipy_special;
 pub use scipy_special::boxcox::{boxcox, boxcox1p, inv_boxcox, inv_boxcox1p};


### PR DESCRIPTION
This adds the undocumented (yet secretly public) `lgam1p` Cephes function, corresponding to the very private and very internal SciPy function `scipy.special._ufuncs._lgam1p` that's documented as 

> Internal function, do not use.

which seems to be aimed at those that did not yet realize that the private function (because of the `_` prefix) of the private module (because of the `_` prefix) that doesn't appear in the documentation (because it's private) is, in fact, a private function.

Anyway, since I'm not really sure whether `lgam1p` is public api or not, I figured I should probably just add it to `xsf`, because you never know :shrug:. If I'm wrong; then sorry for publically exposing your private parts, SciPy, but after seeing it, I just could help myself.

Closes #75