### PR TITLE
update dependencies and package metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,6 +311,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -535,6 +536,16 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ rust-version = "1.85.1"
 description = "Bindings for SciPy special functions"
 
 [build-dependencies]
-bindgen = { version = "0.72.1", default-features = false }
 cc = "1.2.41"
+bindgen = { version = "0.72.1", default-features = false, features = ["runtime"] }
 
 [dependencies]
 num-complex = { version = "0.4.6", default-features = false }


### PR DESCRIPTION
Introduce a new `no-std` package category, update the package description for clarity, bump the `cc` dependency version, and disable default features for `bindgen`.