### PR TITLE
fix `hypu`

### DIFF
--- a/src/xsf/specfun.rs
+++ b/src/xsf/specfun.rs
@@ -156,7 +156,7 @@ pub fn hypu(a: f64, b: f64, x: f64) -> f64 {
         f64::NAN
     } else if x == 0.0 {
         if b > 1.0 {
-            // Singular. DMLF 13.2.16-18
+            // Singular. DLMF 13.2.16-18
             f64::INFINITY
         } else {
             // DLMF 13.2.14-15 and 13.2.19-21


### PR DESCRIPTION
This ports the `scipy.special.hyperu` special-cases ([src](https://github.com/scipy/scipy/blob/11cb6dff61baf0c8d3bf07b7b59a3e7e56fec60b/scipy/special/_hypergeometric.pxd#L8)) to `xsf::hypu`, improving numerical accuracy for certain arguments, and fixing edge-case behavior.